### PR TITLE
Build headers into a static library for use in other projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,24 +30,33 @@ find_package(Threads REQUIRED)
 # sdbus-c++-xml2cpp dbus/org.rogcore.Daemon.xml --proxy=dbus/OrgRogcoreDaemonProxy.h && clang-format -i dbus/OrgRogcoreDaemonProxy.h
 
 # Common options to the service and the client
-add_library(zephyrusbling_common INTERFACE)
-target_compile_features(zephyrusbling_common INTERFACE cxx_std_17)
-target_compile_options(zephyrusbling_common INTERFACE -Wall -Wextra -pedantic -fdiagnostics-color=always -Werror)
-target_compile_options(zephyrusbling_common INTERFACE -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable)
+add_library(zephyrusbling_common STATIC
+	Leds.cpp
+	Image.cpp
+	Bling.cpp
+	BlingDaemon.cpp
+	Effects.cpp
+)
+# Include ${CMAKE_CURRENT_LIST_DIR}/../ to make CMake generate zephyrusbling/<header>.h imports for external project
+# instead of just <header>.h
+target_include_directories(zephyrusbling_common PUBLIC "${CMAKE_CURRENT_LIST_DIR}/../")
+target_compile_features(zephyrusbling_common PUBLIC cxx_std_17)
+target_compile_options(zephyrusbling_common PUBLIC -Wall -Wextra -pedantic -fdiagnostics-color=always -Werror)
+target_compile_options(zephyrusbling_common PUBLIC -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable)
 
-target_compile_options(zephyrusbling_common INTERFACE -fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fno-omit-frame-pointer)
-target_compile_options(zephyrusbling_common INTERFACE -fsanitize=leak)
+target_compile_options(zephyrusbling_common PUBLIC -fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fno-omit-frame-pointer)
+target_compile_options(zephyrusbling_common PUBLIC -fsanitize=leak)
 # target_compile_options(zephyrusbling_common INTERFACE -fsanitize=thread)
-target_compile_options(zephyrusbling_common INTERFACE -fsanitize=undefined)
-target_compile_options(zephyrusbling_common INTERFACE -fsanitize-address-use-after-scope)
+target_compile_options(zephyrusbling_common PUBLIC -fsanitize=undefined)
+target_compile_options(zephyrusbling_common PUBLIC -fsanitize-address-use-after-scope)
 
-target_link_options(zephyrusbling_common INTERFACE -fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fno-omit-frame-pointer)
-target_link_options(zephyrusbling_common INTERFACE -fsanitize=leak)
+target_link_options(zephyrusbling_common PUBLIC -fsanitize=address -fsanitize=pointer-compare -fsanitize=pointer-subtract -fno-omit-frame-pointer)
+target_link_options(zephyrusbling_common PUBLIC -fsanitize=leak)
 # target_link_options(zephyrusbling_common INTERFACE -fsanitize=thread)
-target_link_options(zephyrusbling_common INTERFACE -fsanitize=undefined)
-target_link_options(zephyrusbling_common INTERFACE -fsanitize-address-use-after-scope)
+target_link_options(zephyrusbling_common PUBLIC -fsanitize=undefined)
+target_link_options(zephyrusbling_common PUBLIC -fsanitize-address-use-after-scope)
 
-target_link_libraries(zephyrusbling_common INTERFACE
+target_link_libraries(zephyrusbling_common
 	Boost::boost
 	fmt::fmt
 	Microsoft.GSL::GSL


### PR DESCRIPTION
I wanted to be able to use ZephyrusBling's functions in other applications so I modified CMakeLists.txt to also export `zephyrusbling_common` as a static library. I also have a fully working external project prototype using `include_subdirectory()` with ZephyrusBling as a git submodule. First commit message:
> Updated CMakeLists.txt to also build headers as a static library to be imported in other programs